### PR TITLE
The legacy dos require using container from context manager

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -13,3 +13,4 @@ def py_container(tmp_path):
     cnt = PyContainer(tmp_path)
     cnt.init_container()
     yield cnt
+    cnt.close()


### PR DESCRIPTION
The API is complex, otherwise if the handler not cleaned it will hit "too many file open" issue. RS don't have this problem.

Try my best to make tests for legacy dos pass. 